### PR TITLE
Adjust default app port mapping

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -135,6 +135,11 @@ gcloud compute firewall-rules create allow-http \
 gcloud compute firewall-rules create allow-https \
   --allow tcp:443 --source-ranges 0.0.0.0/0 --target-tags https-server
 
+# Allow direct access to the application port if you're not using the nginx profile
+# (adjust 5000 if you've changed APP_PORT)
+gcloud compute firewall-rules create allow-app-port \
+  --allow tcp:5000 --source-ranges 0.0.0.0/0 --target-tags http-server
+
 # SSH into the instance
 gcloud compute ssh expenselocator-vm
 
@@ -269,12 +274,12 @@ expenselocator-maintenance restart
    sudo chown -R expenselocator:expenselocator /opt/expenselocator
    ```
 
-3. **Port 80 already in use:**
+3. **Application port already in use:**
    ```bash
-   # Check what's using port 80
-   sudo netstat -tulpn | grep :80
-   
-   # Stop conflicting service
+   # Check what's using the application port (default: 5000)
+   sudo netstat -tulpn | grep :5000
+
+   # Stop the conflicting service or change APP_PORT in .env
    sudo systemctl stop apache2  # or nginx
    ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,25 @@ COPY . .
 # Build the application
 RUN npm run build
 
+# Development stage
+FROM node:18-alpine AS development
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files and install all dependencies needed for development
+COPY package*.json ./
+RUN npm ci
+
+# Copy source code (will be overridden by bind mount in development)
+COPY . .
+
+# Expose default development port
+EXPOSE 5000
+
+# Default command for development
+CMD ["npm", "run", "dev"]
+
 # Production stage
 FROM node:18-alpine AS production
 

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -72,7 +72,7 @@ This guide provides instructions for deploying ExpenseLocator in a Docker contai
 | `POSTGRES_PASSWORD` | Database password | Yes |
 | `SESSION_SECRET` | Session encryption key | Yes |
 | `ALLOWED_ORIGINS` | Comma-separated allowed origins | Yes |
-| `APP_PORT` | Application port (default: 80) | No |
+| `APP_PORT` | Application port (default: 5000) | No |
 | `POSTGRES_PORT` | Database port (default: 5432) | No |
 
 ### Replit Authentication Setup
@@ -188,7 +188,7 @@ sudo systemctl status expenselocator
 
 ### Option 2: Using Cloudflare or other CDN
 
-Configure your CDN to proxy requests to your VM's IP address on port 80.
+Configure your CDN to proxy requests to your VM's IP address on the port specified by `APP_PORT` (default: 5000).
 
 ## Monitoring and Logs
 
@@ -302,10 +302,10 @@ The installation script configures UFW with the following rules:
 
 3. **Port conflicts:**
    ```bash
-   # Check what's using port 80
-   sudo netstat -tulpn | grep :80
-   
-   # Change APP_PORT in .env
+   # Check what's using the application port (default: 5000)
+   sudo netstat -tulpn | grep :5000
+
+   # Change APP_PORT in .env if needed
    nano .env
    ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     volumes:
       - uploads_data:/app/uploads
     ports:
-      - "${APP_PORT:-80}:5000"
+      - "${APP_PORT:-5000}:5000"
     networks:
       - expenselocator-network
     healthcheck:


### PR DESCRIPTION
## Summary
- change the docker-compose app service to map the container to host port 5000 by default so running without elevated privileges does not fail on port 80
- update the Docker deployment docs to note the new default port, CDN guidance, and how to troubleshoot port conflicts
- extend the deployment guide with firewall guidance for opening the application port when nginx is not used

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae03225b0832497753135c4f1d608